### PR TITLE
DEV-5: Refactor TestEventCollector gRPC methods and messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "protobuf"]
 	path = protobuf
 	url = https://github.com/stanterprise/protobuf.git
-	tag = v0.0.4
+	tag = v0.0.5

--- a/testsystem/v1/entities/entities.pb.go
+++ b/testsystem/v1/entities/entities.pb.go
@@ -7,8 +7,10 @@
 package entities
 
 import (
+	common "github.com/stanterprise/proto-go/testsystem/v1/common"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -21,32 +23,82 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type TestScript struct {
+type SuiteType int32
+
+const (
+	SuiteType_ROOT     SuiteType = 0
+	SuiteType_PROJECT  SuiteType = 1
+	SuiteType_SUBSUITE SuiteType = 2
+)
+
+// Enum value maps for SuiteType.
+var (
+	SuiteType_name = map[int32]string{
+		0: "ROOT",
+		1: "PROJECT",
+		2: "SUBSUITE",
+	}
+	SuiteType_value = map[string]int32{
+		"ROOT":     0,
+		"PROJECT":  1,
+		"SUBSUITE": 2,
+	}
+)
+
+func (x SuiteType) Enum() *SuiteType {
+	p := new(SuiteType)
+	*p = x
+	return p
+}
+
+func (x SuiteType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SuiteType) Descriptor() protoreflect.EnumDescriptor {
+	return file_testsystem_v1_entities_entities_proto_enumTypes[0].Descriptor()
+}
+
+func (SuiteType) Type() protoreflect.EnumType {
+	return &file_testsystem_v1_entities_entities_proto_enumTypes[0]
+}
+
+func (x SuiteType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SuiteType.Descriptor instead.
+func (SuiteType) EnumDescriptor() ([]byte, []int) {
+	return file_testsystem_v1_entities_entities_proto_rawDescGZIP(), []int{0}
+}
+
+type TestCase struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                                                       // Unique identifier for the test script
 	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`                                                                                   // Name of the test script
 	Description   string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`                                                                     // Description of the test script
-	Steps         []string               `protobuf:"bytes,4,rep,name=steps,proto3" json:"steps,omitempty"`                                                                                 // List of steps in the test script
+	Steps         []*Step                `protobuf:"bytes,4,rep,name=steps,proto3" json:"steps,omitempty"`                                                                                 // List of steps in the test script
 	Metadata      map[string]string      `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Additional metadata for the test script
-	IsActive      *bool                  `protobuf:"varint,6,opt,name=is_active,json=isActive,proto3,oneof" json:"is_active,omitempty"`                                                    // Indicates if the script is currently active or deprecated
+	Status        common.TestStatus      `protobuf:"varint,6,opt,name=status,proto3,enum=testsystem.v1.common.TestStatus" json:"status,omitempty"`                                         // Current status of the test script
+	ParentSuite   *TestSuite             `protobuf:"bytes,7,opt,name=parent_suite,json=parentSuite,proto3" json:"parent_suite,omitempty"`                                                  // Reference to the parent suite, if any
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *TestScript) Reset() {
-	*x = TestScript{}
+func (x *TestCase) Reset() {
+	*x = TestCase{}
 	mi := &file_testsystem_v1_entities_entities_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TestScript) String() string {
+func (x *TestCase) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TestScript) ProtoMessage() {}
+func (*TestCase) ProtoMessage() {}
 
-func (x *TestScript) ProtoReflect() protoreflect.Message {
+func (x *TestCase) ProtoReflect() protoreflect.Message {
 	mi := &file_testsystem_v1_entities_entities_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -58,61 +110,71 @@ func (x *TestScript) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use TestScript.ProtoReflect.Descriptor instead.
-func (*TestScript) Descriptor() ([]byte, []int) {
+// Deprecated: Use TestCase.ProtoReflect.Descriptor instead.
+func (*TestCase) Descriptor() ([]byte, []int) {
 	return file_testsystem_v1_entities_entities_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *TestScript) GetId() string {
+func (x *TestCase) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-func (x *TestScript) GetName() string {
+func (x *TestCase) GetName() string {
 	if x != nil {
 		return x.Name
 	}
 	return ""
 }
 
-func (x *TestScript) GetDescription() string {
+func (x *TestCase) GetDescription() string {
 	if x != nil {
 		return x.Description
 	}
 	return ""
 }
 
-func (x *TestScript) GetSteps() []string {
+func (x *TestCase) GetSteps() []*Step {
 	if x != nil {
 		return x.Steps
 	}
 	return nil
 }
 
-func (x *TestScript) GetMetadata() map[string]string {
+func (x *TestCase) GetMetadata() map[string]string {
 	if x != nil {
 		return x.Metadata
 	}
 	return nil
 }
 
-func (x *TestScript) GetIsActive() bool {
-	if x != nil && x.IsActive != nil {
-		return *x.IsActive
+func (x *TestCase) GetStatus() common.TestStatus {
+	if x != nil {
+		return x.Status
 	}
-	return false
+	return common.TestStatus(0)
+}
+
+func (x *TestCase) GetParentSuite() *TestSuite {
+	if x != nil {
+		return x.ParentSuite
+	}
+	return nil
 }
 
 type TestSuite struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                                                       // Unique identifier for the test suite
 	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`                                                                                   // Name of the test suite
-	Scripts       []*TestScript          `protobuf:"bytes,3,rep,name=scripts,proto3" json:"scripts,omitempty"`                                                                             // List of test scripts in the suite
-	Description   string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`                                                                     // Optional description of the test suite
-	Metadata      map[string]string      `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Additional metadata for the test suite
-	SubSuites     []*TestSuite           `protobuf:"bytes,6,rep,name=sub_suites,json=subSuites,proto3" json:"sub_suites,omitempty"`                                                        // Nested test suites
+	Tests         []*TestCase            `protobuf:"bytes,3,rep,name=tests,proto3" json:"tests,omitempty"`                                                                                 // List of test cases in the suite
+	SubSuites     []*TestSuite           `protobuf:"bytes,4,rep,name=sub_suites,json=subSuites,proto3" json:"sub_suites,omitempty"`                                                        // Nested test suites
+	Description   string                 `protobuf:"bytes,5,opt,name=description,proto3" json:"description,omitempty"`                                                                     // Optional description of the test suite
+	Location      string                 `protobuf:"bytes,6,opt,name=location,proto3" json:"location,omitempty"`                                                                           // Location or path of the test suite definition
+	Metadata      map[string]string      `protobuf:"bytes,7,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Additional metadata for the test suite
+	Type          SuiteType              `protobuf:"varint,8,opt,name=type,proto3,enum=testsystem.v1.entities.SuiteType" json:"type,omitempty"`                                            // Type of the test suite (e.g., "root", "project", "subsuite")
+	ParentSuite   *TestSuite             `protobuf:"bytes,9,opt,name=parent_suite,json=parentSuite,proto3" json:"parent_suite,omitempty"`                                                  // Reference to the parent suite, if any
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -161,23 +223,9 @@ func (x *TestSuite) GetName() string {
 	return ""
 }
 
-func (x *TestSuite) GetScripts() []*TestScript {
+func (x *TestSuite) GetTests() []*TestCase {
 	if x != nil {
-		return x.Scripts
-	}
-	return nil
-}
-
-func (x *TestSuite) GetDescription() string {
-	if x != nil {
-		return x.Description
-	}
-	return ""
-}
-
-func (x *TestSuite) GetMetadata() map[string]string {
-	if x != nil {
-		return x.Metadata
+		return x.Tests
 	}
 	return nil
 }
@@ -189,35 +237,376 @@ func (x *TestSuite) GetSubSuites() []*TestSuite {
 	return nil
 }
 
+func (x *TestSuite) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *TestSuite) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
+func (x *TestSuite) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *TestSuite) GetType() SuiteType {
+	if x != nil {
+		return x.Type
+	}
+	return SuiteType_ROOT
+}
+
+func (x *TestSuite) GetParentSuite() *TestSuite {
+	if x != nil {
+		return x.ParentSuite
+	}
+	return nil
+}
+
+type Step struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                                                       // Unique identifier for the test result
+	TestId        string                 `protobuf:"bytes,2,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`                                                                 // Reference to the test case
+	Title         string                 `protobuf:"bytes,3,opt,name=title,proto3" json:"title,omitempty"`                                                                                 // Title of the test result
+	Description   string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`                                                                     // Description of the step
+	StartTime     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`                                                        // Start time of the test execution
+	Type          string                 `protobuf:"bytes,6,opt,name=type,proto3" json:"type,omitempty"`                                                                                   // Type of the step (e.g., "setup", "execution", "validation")
+	Duration      int64                  `protobuf:"varint,7,opt,name=duration,proto3" json:"duration,omitempty"`                                                                          // Estimated duration in seconds
+	Metadata      map[string]string      `protobuf:"bytes,8,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Additional metadata for the step
+	ParentStepId  string                 `protobuf:"bytes,9,opt,name=parent_step_id,json=parentStepId,proto3" json:"parent_step_id,omitempty"`                                             // Reference to the parent step for nested steps
+	SubSteps      []*Step                `protobuf:"bytes,10,rep,name=sub_steps,json=subSteps,proto3" json:"sub_steps,omitempty"`                                                          // Nested steps
+	WorkerIndex   string                 `protobuf:"bytes,11,opt,name=worker_index,json=workerIndex,proto3" json:"worker_index,omitempty"`                                                 // Identifier for the worker executing the step
+	Status        common.TestStatus      `protobuf:"varint,12,opt,name=status,proto3,enum=testsystem.v1.common.TestStatus" json:"status,omitempty"`                                        // Result status (e.g., "passed", "failed", "skipped")
+	Error         string                 `protobuf:"bytes,13,opt,name=error,proto3" json:"error,omitempty"`                                                                                // Error message if the step failed
+	Location      string                 `protobuf:"bytes,14,opt,name=location,proto3" json:"location,omitempty"`                                                                          // Location in the code where the step is defined
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Step) Reset() {
+	*x = Step{}
+	mi := &file_testsystem_v1_entities_entities_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Step) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Step) ProtoMessage() {}
+
+func (x *Step) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_entities_entities_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Step.ProtoReflect.Descriptor instead.
+func (*Step) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_entities_entities_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *Step) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Step) GetTestId() string {
+	if x != nil {
+		return x.TestId
+	}
+	return ""
+}
+
+func (x *Step) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *Step) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *Step) GetStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTime
+	}
+	return nil
+}
+
+func (x *Step) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *Step) GetDuration() int64 {
+	if x != nil {
+		return x.Duration
+	}
+	return 0
+}
+
+func (x *Step) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *Step) GetParentStepId() string {
+	if x != nil {
+		return x.ParentStepId
+	}
+	return ""
+}
+
+func (x *Step) GetSubSteps() []*Step {
+	if x != nil {
+		return x.SubSteps
+	}
+	return nil
+}
+
+func (x *Step) GetWorkerIndex() string {
+	if x != nil {
+		return x.WorkerIndex
+	}
+	return ""
+}
+
+func (x *Step) GetStatus() common.TestStatus {
+	if x != nil {
+		return x.Status
+	}
+	return common.TestStatus(0)
+}
+
+func (x *Step) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *Step) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
+type TestResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                                                       // Unique identifier for the test result
+	TestId        string                 `protobuf:"bytes,2,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`                                                                 // Reference to the test case
+	Title         string                 `protobuf:"bytes,3,opt,name=title,proto3" json:"title,omitempty"`                                                                                 // Title of the test result
+	Status        common.TestStatus      `protobuf:"varint,4,opt,name=status,proto3,enum=testsystem.v1.common.TestStatus" json:"status,omitempty"`                                         // Result status (e.g., "passed", "failed", "skipped")
+	StartTime     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`                                                        // Start time of the test execution
+	Attachments   []*common.Attachment   `protobuf:"bytes,6,rep,name=attachments,proto3" json:"attachments,omitempty"`                                                                     // Attachments related to the test result
+	ErrorMessage  string                 `protobuf:"bytes,7,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`                                               // Error message if the test failed
+	StackTrace    string                 `protobuf:"bytes,8,opt,name=stack_trace,json=stackTrace,proto3" json:"stack_trace,omitempty"`                                                     // Stack trace if applicable
+	Metadata      map[string]string      `protobuf:"bytes,9,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Additional metadata for the test result
+	Errors        []string               `protobuf:"bytes,11,rep,name=errors,proto3" json:"errors,omitempty"`                                                                              // List of error messages if any
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TestResult) Reset() {
+	*x = TestResult{}
+	mi := &file_testsystem_v1_entities_entities_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TestResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TestResult) ProtoMessage() {}
+
+func (x *TestResult) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_entities_entities_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TestResult.ProtoReflect.Descriptor instead.
+func (*TestResult) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_entities_entities_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *TestResult) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *TestResult) GetTestId() string {
+	if x != nil {
+		return x.TestId
+	}
+	return ""
+}
+
+func (x *TestResult) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *TestResult) GetStatus() common.TestStatus {
+	if x != nil {
+		return x.Status
+	}
+	return common.TestStatus(0)
+}
+
+func (x *TestResult) GetStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTime
+	}
+	return nil
+}
+
+func (x *TestResult) GetAttachments() []*common.Attachment {
+	if x != nil {
+		return x.Attachments
+	}
+	return nil
+}
+
+func (x *TestResult) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *TestResult) GetStackTrace() string {
+	if x != nil {
+		return x.StackTrace
+	}
+	return ""
+}
+
+func (x *TestResult) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *TestResult) GetErrors() []string {
+	if x != nil {
+		return x.Errors
+	}
+	return nil
+}
+
 var File_testsystem_v1_entities_entities_proto protoreflect.FileDescriptor
 
 const file_testsystem_v1_entities_entities_proto_rawDesc = "" +
 	"\n" +
-	"%testsystem/v1/entities/entities.proto\x12\x16testsystem.v1.entities\"\xa3\x02\n" +
-	"\n" +
-	"TestScript\x12\x0e\n" +
+	"%testsystem/v1/entities/entities.proto\x12\x16testsystem.v1.entities\x1a!testsystem/v1/common/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8d\x03\n" +
+	"\bTestCase\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
-	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x14\n" +
-	"\x05steps\x18\x04 \x03(\tR\x05steps\x12L\n" +
-	"\bmetadata\x18\x05 \x03(\v20.testsystem.v1.entities.TestScript.MetadataEntryR\bmetadata\x12 \n" +
-	"\tis_active\x18\x06 \x01(\bH\x00R\bisActive\x88\x01\x01\x1a;\n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x122\n" +
+	"\x05steps\x18\x04 \x03(\v2\x1c.testsystem.v1.entities.StepR\x05steps\x12J\n" +
+	"\bmetadata\x18\x05 \x03(\v2..testsystem.v1.entities.TestCase.MetadataEntryR\bmetadata\x128\n" +
+	"\x06status\x18\x06 \x01(\x0e2 .testsystem.v1.common.TestStatusR\x06status\x12D\n" +
+	"\fparent_suite\x18\a \x01(\v2!.testsystem.v1.entities.TestSuiteR\vparentSuite\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\f\n" +
-	"\n" +
-	"_is_active\"\xdb\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xee\x03\n" +
 	"\tTestSuite\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12<\n" +
-	"\ascripts\x18\x03 \x03(\v2\".testsystem.v1.entities.TestScriptR\ascripts\x12 \n" +
-	"\vdescription\x18\x04 \x01(\tR\vdescription\x12K\n" +
-	"\bmetadata\x18\x05 \x03(\v2/.testsystem.v1.entities.TestSuite.MetadataEntryR\bmetadata\x12@\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x126\n" +
+	"\x05tests\x18\x03 \x03(\v2 .testsystem.v1.entities.TestCaseR\x05tests\x12@\n" +
 	"\n" +
-	"sub_suites\x18\x06 \x03(\v2!.testsystem.v1.entities.TestSuiteR\tsubSuites\x1a;\n" +
+	"sub_suites\x18\x04 \x03(\v2!.testsystem.v1.entities.TestSuiteR\tsubSuites\x12 \n" +
+	"\vdescription\x18\x05 \x01(\tR\vdescription\x12\x1a\n" +
+	"\blocation\x18\x06 \x01(\tR\blocation\x12K\n" +
+	"\bmetadata\x18\a \x03(\v2/.testsystem.v1.entities.TestSuite.MetadataEntryR\bmetadata\x125\n" +
+	"\x04type\x18\b \x01(\x0e2!.testsystem.v1.entities.SuiteTypeR\x04type\x12D\n" +
+	"\fparent_suite\x18\t \x01(\v2!.testsystem.v1.entities.TestSuiteR\vparentSuite\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01Bd\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc7\x04\n" +
+	"\x04Step\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
+	"\atest_id\x18\x02 \x01(\tR\x06testId\x12\x14\n" +
+	"\x05title\x18\x03 \x01(\tR\x05title\x12 \n" +
+	"\vdescription\x18\x04 \x01(\tR\vdescription\x129\n" +
+	"\n" +
+	"start_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12\x12\n" +
+	"\x04type\x18\x06 \x01(\tR\x04type\x12\x1a\n" +
+	"\bduration\x18\a \x01(\x03R\bduration\x12F\n" +
+	"\bmetadata\x18\b \x03(\v2*.testsystem.v1.entities.Step.MetadataEntryR\bmetadata\x12$\n" +
+	"\x0eparent_step_id\x18\t \x01(\tR\fparentStepId\x129\n" +
+	"\tsub_steps\x18\n" +
+	" \x03(\v2\x1c.testsystem.v1.entities.StepR\bsubSteps\x12!\n" +
+	"\fworker_index\x18\v \x01(\tR\vworkerIndex\x128\n" +
+	"\x06status\x18\f \x01(\x0e2 .testsystem.v1.common.TestStatusR\x06status\x12\x14\n" +
+	"\x05error\x18\r \x01(\tR\x05error\x12\x1a\n" +
+	"\blocation\x18\x0e \x01(\tR\blocation\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xed\x03\n" +
+	"\n" +
+	"TestResult\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
+	"\atest_id\x18\x02 \x01(\tR\x06testId\x12\x14\n" +
+	"\x05title\x18\x03 \x01(\tR\x05title\x128\n" +
+	"\x06status\x18\x04 \x01(\x0e2 .testsystem.v1.common.TestStatusR\x06status\x129\n" +
+	"\n" +
+	"start_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12B\n" +
+	"\vattachments\x18\x06 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\x12#\n" +
+	"\rerror_message\x18\a \x01(\tR\ferrorMessage\x12\x1f\n" +
+	"\vstack_trace\x18\b \x01(\tR\n" +
+	"stackTrace\x12L\n" +
+	"\bmetadata\x18\t \x03(\v20.testsystem.v1.entities.TestResult.MetadataEntryR\bmetadata\x12\x16\n" +
+	"\x06errors\x18\v \x03(\tR\x06errors\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*0\n" +
+	"\tSuiteType\x12\b\n" +
+	"\x04ROOT\x10\x00\x12\v\n" +
+	"\aPROJECT\x10\x01\x12\f\n" +
+	"\bSUBSUITE\x10\x02Bd\n" +
 	"'com.stanterprise.testsystem.v1.entitiesP\x01Z7github.com/stanterprise/proto-go/testsystem/v1/entitiesb\x06proto3"
 
 var (
@@ -232,23 +621,45 @@ func file_testsystem_v1_entities_entities_proto_rawDescGZIP() []byte {
 	return file_testsystem_v1_entities_entities_proto_rawDescData
 }
 
-var file_testsystem_v1_entities_entities_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_testsystem_v1_entities_entities_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_testsystem_v1_entities_entities_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_testsystem_v1_entities_entities_proto_goTypes = []any{
-	(*TestScript)(nil), // 0: testsystem.v1.entities.TestScript
-	(*TestSuite)(nil),  // 1: testsystem.v1.entities.TestSuite
-	nil,                // 2: testsystem.v1.entities.TestScript.MetadataEntry
-	nil,                // 3: testsystem.v1.entities.TestSuite.MetadataEntry
+	(SuiteType)(0),                // 0: testsystem.v1.entities.SuiteType
+	(*TestCase)(nil),              // 1: testsystem.v1.entities.TestCase
+	(*TestSuite)(nil),             // 2: testsystem.v1.entities.TestSuite
+	(*Step)(nil),                  // 3: testsystem.v1.entities.Step
+	(*TestResult)(nil),            // 4: testsystem.v1.entities.TestResult
+	nil,                           // 5: testsystem.v1.entities.TestCase.MetadataEntry
+	nil,                           // 6: testsystem.v1.entities.TestSuite.MetadataEntry
+	nil,                           // 7: testsystem.v1.entities.Step.MetadataEntry
+	nil,                           // 8: testsystem.v1.entities.TestResult.MetadataEntry
+	(common.TestStatus)(0),        // 9: testsystem.v1.common.TestStatus
+	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
+	(*common.Attachment)(nil),     // 11: testsystem.v1.common.Attachment
 }
 var file_testsystem_v1_entities_entities_proto_depIdxs = []int32{
-	2, // 0: testsystem.v1.entities.TestScript.metadata:type_name -> testsystem.v1.entities.TestScript.MetadataEntry
-	0, // 1: testsystem.v1.entities.TestSuite.scripts:type_name -> testsystem.v1.entities.TestScript
-	3, // 2: testsystem.v1.entities.TestSuite.metadata:type_name -> testsystem.v1.entities.TestSuite.MetadataEntry
-	1, // 3: testsystem.v1.entities.TestSuite.sub_suites:type_name -> testsystem.v1.entities.TestSuite
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	3,  // 0: testsystem.v1.entities.TestCase.steps:type_name -> testsystem.v1.entities.Step
+	5,  // 1: testsystem.v1.entities.TestCase.metadata:type_name -> testsystem.v1.entities.TestCase.MetadataEntry
+	9,  // 2: testsystem.v1.entities.TestCase.status:type_name -> testsystem.v1.common.TestStatus
+	2,  // 3: testsystem.v1.entities.TestCase.parent_suite:type_name -> testsystem.v1.entities.TestSuite
+	1,  // 4: testsystem.v1.entities.TestSuite.tests:type_name -> testsystem.v1.entities.TestCase
+	2,  // 5: testsystem.v1.entities.TestSuite.sub_suites:type_name -> testsystem.v1.entities.TestSuite
+	6,  // 6: testsystem.v1.entities.TestSuite.metadata:type_name -> testsystem.v1.entities.TestSuite.MetadataEntry
+	0,  // 7: testsystem.v1.entities.TestSuite.type:type_name -> testsystem.v1.entities.SuiteType
+	2,  // 8: testsystem.v1.entities.TestSuite.parent_suite:type_name -> testsystem.v1.entities.TestSuite
+	10, // 9: testsystem.v1.entities.Step.start_time:type_name -> google.protobuf.Timestamp
+	7,  // 10: testsystem.v1.entities.Step.metadata:type_name -> testsystem.v1.entities.Step.MetadataEntry
+	3,  // 11: testsystem.v1.entities.Step.sub_steps:type_name -> testsystem.v1.entities.Step
+	9,  // 12: testsystem.v1.entities.Step.status:type_name -> testsystem.v1.common.TestStatus
+	9,  // 13: testsystem.v1.entities.TestResult.status:type_name -> testsystem.v1.common.TestStatus
+	10, // 14: testsystem.v1.entities.TestResult.start_time:type_name -> google.protobuf.Timestamp
+	11, // 15: testsystem.v1.entities.TestResult.attachments:type_name -> testsystem.v1.common.Attachment
+	8,  // 16: testsystem.v1.entities.TestResult.metadata:type_name -> testsystem.v1.entities.TestResult.MetadataEntry
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_testsystem_v1_entities_entities_proto_init() }
@@ -256,19 +667,19 @@ func file_testsystem_v1_entities_entities_proto_init() {
 	if File_testsystem_v1_entities_entities_proto != nil {
 		return
 	}
-	file_testsystem_v1_entities_entities_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_testsystem_v1_entities_entities_proto_rawDesc), len(file_testsystem_v1_entities_entities_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   4,
+			NumEnums:      1,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_testsystem_v1_entities_entities_proto_goTypes,
 		DependencyIndexes: file_testsystem_v1_entities_entities_proto_depIdxs,
+		EnumInfos:         file_testsystem_v1_entities_entities_proto_enumTypes,
 		MessageInfos:      file_testsystem_v1_entities_entities_proto_msgTypes,
 	}.Build()
 	File_testsystem_v1_entities_entities_proto = out.File

--- a/testsystem/v1/events/events.pb.go
+++ b/testsystem/v1/events/events.pb.go
@@ -8,6 +8,7 @@ package events
 
 import (
 	common "github.com/stanterprise/proto-go/testsystem/v1/common"
+	entities "github.com/stanterprise/proto-go/testsystem/v1/entities"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
@@ -23,30 +24,27 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type TestStartEventRequest struct {
+type TestBeginEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
-	TestName      string                 `protobuf:"bytes,2,opt,name=test_name,json=testName,proto3" json:"test_name,omitempty"`
-	StartTime     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	Metadata      map[string]string      `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Additional metadata
+	TestCase      *entities.TestCase     `protobuf:"bytes,1,opt,name=test_case,json=testCase,proto3" json:"test_case,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *TestStartEventRequest) Reset() {
-	*x = TestStartEventRequest{}
+func (x *TestBeginEventRequest) Reset() {
+	*x = TestBeginEventRequest{}
 	mi := &file_testsystem_v1_events_events_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TestStartEventRequest) String() string {
+func (x *TestBeginEventRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TestStartEventRequest) ProtoMessage() {}
+func (*TestBeginEventRequest) ProtoMessage() {}
 
-func (x *TestStartEventRequest) ProtoReflect() protoreflect.Message {
+func (x *TestBeginEventRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_testsystem_v1_events_events_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -58,65 +56,39 @@ func (x *TestStartEventRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use TestStartEventRequest.ProtoReflect.Descriptor instead.
-func (*TestStartEventRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use TestBeginEventRequest.ProtoReflect.Descriptor instead.
+func (*TestBeginEventRequest) Descriptor() ([]byte, []int) {
 	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *TestStartEventRequest) GetTestId() string {
+func (x *TestBeginEventRequest) GetTestCase() *entities.TestCase {
 	if x != nil {
-		return x.TestId
-	}
-	return ""
-}
-
-func (x *TestStartEventRequest) GetTestName() string {
-	if x != nil {
-		return x.TestName
-	}
-	return ""
-}
-
-func (x *TestStartEventRequest) GetStartTime() *timestamppb.Timestamp {
-	if x != nil {
-		return x.StartTime
+		return x.TestCase
 	}
 	return nil
 }
 
-func (x *TestStartEventRequest) GetMetadata() map[string]string {
-	if x != nil {
-		return x.Metadata
-	}
-	return nil
-}
-
-type TestFinishEventRequest struct {
+type TestEndEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
-	Status        common.TestStatus      `protobuf:"varint,2,opt,name=status,proto3,enum=testsystem.v1.common.TestStatus" json:"status,omitempty"`
-	EndTime       *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
-	Attachments   []*common.Attachment   `protobuf:"bytes,4,rep,name=attachments,proto3" json:"attachments,omitempty"`
-	ErrorMessage  string                 `protobuf:"bytes,5,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"` // If any
-	StackTrace    string                 `protobuf:"bytes,6,opt,name=stack_trace,json=stackTrace,proto3" json:"stack_trace,omitempty"`       // If any
+	TestCase      *entities.TestCase     `protobuf:"bytes,1,opt,name=test_case,json=testCase,proto3" json:"test_case,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *TestFinishEventRequest) Reset() {
-	*x = TestFinishEventRequest{}
+func (x *TestEndEventRequest) Reset() {
+	*x = TestEndEventRequest{}
 	mi := &file_testsystem_v1_events_events_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TestFinishEventRequest) String() string {
+func (x *TestEndEventRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TestFinishEventRequest) ProtoMessage() {}
+func (*TestEndEventRequest) ProtoMessage() {}
 
-func (x *TestFinishEventRequest) ProtoReflect() protoreflect.Message {
+func (x *TestEndEventRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_testsystem_v1_events_events_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -128,144 +100,208 @@ func (x *TestFinishEventRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use TestFinishEventRequest.ProtoReflect.Descriptor instead.
-func (*TestFinishEventRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use TestEndEventRequest.ProtoReflect.Descriptor instead.
+func (*TestEndEventRequest) Descriptor() ([]byte, []int) {
 	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *TestFinishEventRequest) GetTestId() string {
+func (x *TestEndEventRequest) GetTestCase() *entities.TestCase {
+	if x != nil {
+		return x.TestCase
+	}
+	return nil
+}
+
+type StepBeginEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Step          *entities.Step         `protobuf:"bytes,1,opt,name=step,proto3" json:"step,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StepBeginEventRequest) Reset() {
+	*x = StepBeginEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StepBeginEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StepBeginEventRequest) ProtoMessage() {}
+
+func (x *StepBeginEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StepBeginEventRequest.ProtoReflect.Descriptor instead.
+func (*StepBeginEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *StepBeginEventRequest) GetStep() *entities.Step {
+	if x != nil {
+		return x.Step
+	}
+	return nil
+}
+
+type StepEndEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Step          *entities.Step         `protobuf:"bytes,1,opt,name=step,proto3" json:"step,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StepEndEventRequest) Reset() {
+	*x = StepEndEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StepEndEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StepEndEventRequest) ProtoMessage() {}
+
+func (x *StepEndEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StepEndEventRequest.ProtoReflect.Descriptor instead.
+func (*StepEndEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *StepEndEventRequest) GetStep() *entities.Step {
+	if x != nil {
+		return x.Step
+	}
+	return nil
+}
+
+type TestFailureEventRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	TestId         string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
+	FailureMessage string                 `protobuf:"bytes,2,opt,name=failure_message,json=failureMessage,proto3" json:"failure_message,omitempty"`
+	StackTrace     string                 `protobuf:"bytes,3,opt,name=stack_trace,json=stackTrace,proto3" json:"stack_trace,omitempty"`
+	Timestamp      *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Attachments    []*common.Attachment   `protobuf:"bytes,5,rep,name=attachments,proto3" json:"attachments,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *TestFailureEventRequest) Reset() {
+	*x = TestFailureEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TestFailureEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TestFailureEventRequest) ProtoMessage() {}
+
+func (x *TestFailureEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TestFailureEventRequest.ProtoReflect.Descriptor instead.
+func (*TestFailureEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *TestFailureEventRequest) GetTestId() string {
 	if x != nil {
 		return x.TestId
 	}
 	return ""
 }
 
-func (x *TestFinishEventRequest) GetStatus() common.TestStatus {
+func (x *TestFailureEventRequest) GetFailureMessage() string {
 	if x != nil {
-		return x.Status
-	}
-	return common.TestStatus(0)
-}
-
-func (x *TestFinishEventRequest) GetEndTime() *timestamppb.Timestamp {
-	if x != nil {
-		return x.EndTime
-	}
-	return nil
-}
-
-func (x *TestFinishEventRequest) GetAttachments() []*common.Attachment {
-	if x != nil {
-		return x.Attachments
-	}
-	return nil
-}
-
-func (x *TestFinishEventRequest) GetErrorMessage() string {
-	if x != nil {
-		return x.ErrorMessage
+		return x.FailureMessage
 	}
 	return ""
 }
 
-func (x *TestFinishEventRequest) GetStackTrace() string {
+func (x *TestFailureEventRequest) GetStackTrace() string {
 	if x != nil {
 		return x.StackTrace
 	}
 	return ""
 }
 
-type TestStepRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Description   string                 `protobuf:"bytes,1,opt,name=description,proto3" json:"description,omitempty"`
-	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Status        common.TestStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=testsystem.v1.common.TestStatus" json:"status,omitempty"`
-	Attachments   []*common.Attachment   `protobuf:"bytes,4,rep,name=attachments,proto3" json:"attachments,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *TestStepRequest) Reset() {
-	*x = TestStepRequest{}
-	mi := &file_testsystem_v1_events_events_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TestStepRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TestStepRequest) ProtoMessage() {}
-
-func (x *TestStepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_testsystem_v1_events_events_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TestStepRequest.ProtoReflect.Descriptor instead.
-func (*TestStepRequest) Descriptor() ([]byte, []int) {
-	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *TestStepRequest) GetDescription() string {
-	if x != nil {
-		return x.Description
-	}
-	return ""
-}
-
-func (x *TestStepRequest) GetTimestamp() *timestamppb.Timestamp {
+func (x *TestFailureEventRequest) GetTimestamp() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Timestamp
 	}
 	return nil
 }
 
-func (x *TestStepRequest) GetStatus() common.TestStatus {
-	if x != nil {
-		return x.Status
-	}
-	return common.TestStatus(0)
-}
-
-func (x *TestStepRequest) GetAttachments() []*common.Attachment {
+func (x *TestFailureEventRequest) GetAttachments() []*common.Attachment {
 	if x != nil {
 		return x.Attachments
 	}
 	return nil
 }
 
-type TestStepEventRequest struct {
+type TestErrorEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
-	Steps         []*TestStepRequest     `protobuf:"bytes,2,rep,name=steps,proto3" json:"steps,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	StackTrace    string                 `protobuf:"bytes,3,opt,name=stack_trace,json=stackTrace,proto3" json:"stack_trace,omitempty"`
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Attachments   []*common.Attachment   `protobuf:"bytes,5,rep,name=attachments,proto3" json:"attachments,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *TestStepEventRequest) Reset() {
-	*x = TestStepEventRequest{}
-	mi := &file_testsystem_v1_events_events_proto_msgTypes[3]
+func (x *TestErrorEventRequest) Reset() {
+	*x = TestErrorEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TestStepEventRequest) String() string {
+func (x *TestErrorEventRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TestStepEventRequest) ProtoMessage() {}
+func (*TestErrorEventRequest) ProtoMessage() {}
 
-func (x *TestStepEventRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_testsystem_v1_events_events_proto_msgTypes[3]
+func (x *TestErrorEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -276,21 +312,302 @@ func (x *TestStepEventRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use TestStepEventRequest.ProtoReflect.Descriptor instead.
-func (*TestStepEventRequest) Descriptor() ([]byte, []int) {
-	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{3}
+// Deprecated: Use TestErrorEventRequest.ProtoReflect.Descriptor instead.
+func (*TestErrorEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *TestStepEventRequest) GetTestId() string {
+func (x *TestErrorEventRequest) GetTestId() string {
 	if x != nil {
 		return x.TestId
 	}
 	return ""
 }
 
-func (x *TestStepEventRequest) GetSteps() []*TestStepRequest {
+func (x *TestErrorEventRequest) GetErrorMessage() string {
 	if x != nil {
-		return x.Steps
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *TestErrorEventRequest) GetStackTrace() string {
+	if x != nil {
+		return x.StackTrace
+	}
+	return ""
+}
+
+func (x *TestErrorEventRequest) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *TestErrorEventRequest) GetAttachments() []*common.Attachment {
+	if x != nil {
+		return x.Attachments
+	}
+	return nil
+}
+
+type StdErrorEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StdErrorEventRequest) Reset() {
+	*x = StdErrorEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StdErrorEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StdErrorEventRequest) ProtoMessage() {}
+
+func (x *StdErrorEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StdErrorEventRequest.ProtoReflect.Descriptor instead.
+func (*StdErrorEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *StdErrorEventRequest) GetTestId() string {
+	if x != nil {
+		return x.TestId
+	}
+	return ""
+}
+
+func (x *StdErrorEventRequest) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *StdErrorEventRequest) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type StdOutputEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StdOutputEventRequest) Reset() {
+	*x = StdOutputEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StdOutputEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StdOutputEventRequest) ProtoMessage() {}
+
+func (x *StdOutputEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StdOutputEventRequest.ProtoReflect.Descriptor instead.
+func (*StdOutputEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *StdOutputEventRequest) GetTestId() string {
+	if x != nil {
+		return x.TestId
+	}
+	return ""
+}
+
+func (x *StdOutputEventRequest) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *StdOutputEventRequest) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+type SuiteBeginEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Suite         *entities.TestSuite    `protobuf:"bytes,1,opt,name=suite,proto3" json:"suite,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SuiteBeginEventRequest) Reset() {
+	*x = SuiteBeginEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SuiteBeginEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SuiteBeginEventRequest) ProtoMessage() {}
+
+func (x *SuiteBeginEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SuiteBeginEventRequest.ProtoReflect.Descriptor instead.
+func (*SuiteBeginEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SuiteBeginEventRequest) GetSuite() *entities.TestSuite {
+	if x != nil {
+		return x.Suite
+	}
+	return nil
+}
+
+type SuiteEndEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Suite         *entities.TestSuite    `protobuf:"bytes,1,opt,name=suite,proto3" json:"suite,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SuiteEndEventRequest) Reset() {
+	*x = SuiteEndEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SuiteEndEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SuiteEndEventRequest) ProtoMessage() {}
+
+func (x *SuiteEndEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SuiteEndEventRequest.ProtoReflect.Descriptor instead.
+func (*SuiteEndEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *SuiteEndEventRequest) GetSuite() *entities.TestSuite {
+	if x != nil {
+		return x.Suite
+	}
+	return nil
+}
+
+type HeartbeatEventRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SourceId      string                 `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"` // Identifier for the source sending the heartbeat
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HeartbeatEventRequest) Reset() {
+	*x = HeartbeatEventRequest{}
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeartbeatEventRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeartbeatEventRequest) ProtoMessage() {}
+
+func (x *HeartbeatEventRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_testsystem_v1_events_events_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeartbeatEventRequest.ProtoReflect.Descriptor instead.
+func (*HeartbeatEventRequest) Descriptor() ([]byte, []int) {
+	return file_testsystem_v1_events_events_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *HeartbeatEventRequest) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *HeartbeatEventRequest) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
 	}
 	return nil
 }
@@ -299,32 +616,44 @@ var File_testsystem_v1_events_events_proto protoreflect.FileDescriptor
 
 const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\n" +
-	"!testsystem/v1/events/events.proto\x12\x14testsystem.v1.events\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!testsystem/v1/common/common.proto\"\x9c\x02\n" +
-	"\x15TestStartEventRequest\x12\x17\n" +
-	"\atest_id\x18\x01 \x01(\tR\x06testId\x12\x1b\n" +
-	"\ttest_name\x18\x02 \x01(\tR\btestName\x129\n" +
-	"\n" +
-	"start_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12U\n" +
-	"\bmetadata\x18\x04 \x03(\v29.testsystem.v1.events.TestStartEventRequest.MetadataEntryR\bmetadata\x1a;\n" +
-	"\rMetadataEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xac\x02\n" +
-	"\x16TestFinishEventRequest\x12\x17\n" +
-	"\atest_id\x18\x01 \x01(\tR\x06testId\x128\n" +
-	"\x06status\x18\x02 \x01(\x0e2 .testsystem.v1.common.TestStatusR\x06status\x125\n" +
-	"\bend_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\aendTime\x12B\n" +
-	"\vattachments\x18\x04 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\x12#\n" +
-	"\rerror_message\x18\x05 \x01(\tR\ferrorMessage\x12\x1f\n" +
-	"\vstack_trace\x18\x06 \x01(\tR\n" +
-	"stackTrace\"\xeb\x01\n" +
-	"\x0fTestStepRequest\x12 \n" +
-	"\vdescription\x18\x01 \x01(\tR\vdescription\x128\n" +
-	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x128\n" +
-	"\x06status\x18\x03 \x01(\x0e2 .testsystem.v1.common.TestStatusR\x06status\x12B\n" +
-	"\vattachments\x18\x04 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\"l\n" +
-	"\x14TestStepEventRequest\x12\x17\n" +
-	"\atest_id\x18\x01 \x01(\tR\x06testId\x12;\n" +
-	"\x05steps\x18\x02 \x03(\v2%.testsystem.v1.events.TestStepRequestR\x05stepsB`\n" +
+	"!testsystem/v1/events/events.proto\x12\x14testsystem.v1.events\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!testsystem/v1/common/common.proto\x1a%testsystem/v1/entities/entities.proto\"V\n" +
+	"\x15TestBeginEventRequest\x12=\n" +
+	"\ttest_case\x18\x01 \x01(\v2 .testsystem.v1.entities.TestCaseR\btestCase\"T\n" +
+	"\x13TestEndEventRequest\x12=\n" +
+	"\ttest_case\x18\x01 \x01(\v2 .testsystem.v1.entities.TestCaseR\btestCase\"I\n" +
+	"\x15StepBeginEventRequest\x120\n" +
+	"\x04step\x18\x01 \x01(\v2\x1c.testsystem.v1.entities.StepR\x04step\"G\n" +
+	"\x13StepEndEventRequest\x120\n" +
+	"\x04step\x18\x01 \x01(\v2\x1c.testsystem.v1.entities.StepR\x04step\"\xfa\x01\n" +
+	"\x17TestFailureEventRequest\x12\x17\n" +
+	"\atest_id\x18\x01 \x01(\tR\x06testId\x12'\n" +
+	"\x0ffailure_message\x18\x02 \x01(\tR\x0efailureMessage\x12\x1f\n" +
+	"\vstack_trace\x18\x03 \x01(\tR\n" +
+	"stackTrace\x128\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12B\n" +
+	"\vattachments\x18\x05 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\"\xf4\x01\n" +
+	"\x15TestErrorEventRequest\x12\x17\n" +
+	"\atest_id\x18\x01 \x01(\tR\x06testId\x12#\n" +
+	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x1f\n" +
+	"\vstack_trace\x18\x03 \x01(\tR\n" +
+	"stackTrace\x128\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12B\n" +
+	"\vattachments\x18\x05 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\"\x83\x01\n" +
+	"\x14StdErrorEventRequest\x12\x17\n" +
+	"\atest_id\x18\x01 \x01(\tR\x06testId\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x128\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\x84\x01\n" +
+	"\x15StdOutputEventRequest\x12\x17\n" +
+	"\atest_id\x18\x01 \x01(\tR\x06testId\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x128\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"Q\n" +
+	"\x16SuiteBeginEventRequest\x127\n" +
+	"\x05suite\x18\x01 \x01(\v2!.testsystem.v1.entities.TestSuiteR\x05suite\"O\n" +
+	"\x14SuiteEndEventRequest\x127\n" +
+	"\x05suite\x18\x01 \x01(\v2!.testsystem.v1.entities.TestSuiteR\x05suite\"n\n" +
+	"\x15HeartbeatEventRequest\x12\x1b\n" +
+	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x128\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestampB`\n" +
 	"%com.stanterprise.testsystem.v1.eventsP\x01Z5github.com/stanterprise/proto-go/testsystem/v1/eventsb\x06proto3"
 
 var (
@@ -339,32 +668,44 @@ func file_testsystem_v1_events_events_proto_rawDescGZIP() []byte {
 	return file_testsystem_v1_events_events_proto_rawDescData
 }
 
-var file_testsystem_v1_events_events_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_testsystem_v1_events_events_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_testsystem_v1_events_events_proto_goTypes = []any{
-	(*TestStartEventRequest)(nil),  // 0: testsystem.v1.events.TestStartEventRequest
-	(*TestFinishEventRequest)(nil), // 1: testsystem.v1.events.TestFinishEventRequest
-	(*TestStepRequest)(nil),        // 2: testsystem.v1.events.TestStepRequest
-	(*TestStepEventRequest)(nil),   // 3: testsystem.v1.events.TestStepEventRequest
-	nil,                            // 4: testsystem.v1.events.TestStartEventRequest.MetadataEntry
-	(*timestamppb.Timestamp)(nil),  // 5: google.protobuf.Timestamp
-	(common.TestStatus)(0),         // 6: testsystem.v1.common.TestStatus
-	(*common.Attachment)(nil),      // 7: testsystem.v1.common.Attachment
+	(*TestBeginEventRequest)(nil),   // 0: testsystem.v1.events.TestBeginEventRequest
+	(*TestEndEventRequest)(nil),     // 1: testsystem.v1.events.TestEndEventRequest
+	(*StepBeginEventRequest)(nil),   // 2: testsystem.v1.events.StepBeginEventRequest
+	(*StepEndEventRequest)(nil),     // 3: testsystem.v1.events.StepEndEventRequest
+	(*TestFailureEventRequest)(nil), // 4: testsystem.v1.events.TestFailureEventRequest
+	(*TestErrorEventRequest)(nil),   // 5: testsystem.v1.events.TestErrorEventRequest
+	(*StdErrorEventRequest)(nil),    // 6: testsystem.v1.events.StdErrorEventRequest
+	(*StdOutputEventRequest)(nil),   // 7: testsystem.v1.events.StdOutputEventRequest
+	(*SuiteBeginEventRequest)(nil),  // 8: testsystem.v1.events.SuiteBeginEventRequest
+	(*SuiteEndEventRequest)(nil),    // 9: testsystem.v1.events.SuiteEndEventRequest
+	(*HeartbeatEventRequest)(nil),   // 10: testsystem.v1.events.HeartbeatEventRequest
+	(*entities.TestCase)(nil),       // 11: testsystem.v1.entities.TestCase
+	(*entities.Step)(nil),           // 12: testsystem.v1.entities.Step
+	(*timestamppb.Timestamp)(nil),   // 13: google.protobuf.Timestamp
+	(*common.Attachment)(nil),       // 14: testsystem.v1.common.Attachment
+	(*entities.TestSuite)(nil),      // 15: testsystem.v1.entities.TestSuite
 }
 var file_testsystem_v1_events_events_proto_depIdxs = []int32{
-	5, // 0: testsystem.v1.events.TestStartEventRequest.start_time:type_name -> google.protobuf.Timestamp
-	4, // 1: testsystem.v1.events.TestStartEventRequest.metadata:type_name -> testsystem.v1.events.TestStartEventRequest.MetadataEntry
-	6, // 2: testsystem.v1.events.TestFinishEventRequest.status:type_name -> testsystem.v1.common.TestStatus
-	5, // 3: testsystem.v1.events.TestFinishEventRequest.end_time:type_name -> google.protobuf.Timestamp
-	7, // 4: testsystem.v1.events.TestFinishEventRequest.attachments:type_name -> testsystem.v1.common.Attachment
-	5, // 5: testsystem.v1.events.TestStepRequest.timestamp:type_name -> google.protobuf.Timestamp
-	6, // 6: testsystem.v1.events.TestStepRequest.status:type_name -> testsystem.v1.common.TestStatus
-	7, // 7: testsystem.v1.events.TestStepRequest.attachments:type_name -> testsystem.v1.common.Attachment
-	2, // 8: testsystem.v1.events.TestStepEventRequest.steps:type_name -> testsystem.v1.events.TestStepRequest
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	11, // 0: testsystem.v1.events.TestBeginEventRequest.test_case:type_name -> testsystem.v1.entities.TestCase
+	11, // 1: testsystem.v1.events.TestEndEventRequest.test_case:type_name -> testsystem.v1.entities.TestCase
+	12, // 2: testsystem.v1.events.StepBeginEventRequest.step:type_name -> testsystem.v1.entities.Step
+	12, // 3: testsystem.v1.events.StepEndEventRequest.step:type_name -> testsystem.v1.entities.Step
+	13, // 4: testsystem.v1.events.TestFailureEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	14, // 5: testsystem.v1.events.TestFailureEventRequest.attachments:type_name -> testsystem.v1.common.Attachment
+	13, // 6: testsystem.v1.events.TestErrorEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	14, // 7: testsystem.v1.events.TestErrorEventRequest.attachments:type_name -> testsystem.v1.common.Attachment
+	13, // 8: testsystem.v1.events.StdErrorEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	13, // 9: testsystem.v1.events.StdOutputEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	15, // 10: testsystem.v1.events.SuiteBeginEventRequest.suite:type_name -> testsystem.v1.entities.TestSuite
+	15, // 11: testsystem.v1.events.SuiteEndEventRequest.suite:type_name -> testsystem.v1.entities.TestSuite
+	13, // 12: testsystem.v1.events.HeartbeatEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_testsystem_v1_events_events_proto_init() }
@@ -378,7 +719,7 @@ func file_testsystem_v1_events_events_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_testsystem_v1_events_events_proto_rawDesc), len(file_testsystem_v1_events_events_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/testsystem/v1/observer/observer.pb.go
+++ b/testsystem/v1/observer/observer.pb.go
@@ -92,11 +92,19 @@ const file_testsystem_v1_observer_observer_proto_rawDesc = "" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\"\n" +
 	"\n" +
 	"error_code\x18\x03 \x01(\x05H\x00R\terrorCode\x88\x01\x01B\r\n" +
-	"\v_error_code2\xc3\x02\n" +
-	"\x12TestEventCollector\x12c\n" +
-	"\x0fReportTestStart\x12+.testsystem.v1.events.TestStartEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12e\n" +
-	"\x10ReportTestFinish\x12,.testsystem.v1.events.TestFinishEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12a\n" +
-	"\x0eReportTestStep\x12*.testsystem.v1.events.TestStepEventRequest\x1a#.testsystem.v1.observer.AckResponseBd\n" +
+	"\v_error_code2\xdf\b\n" +
+	"\x12TestEventCollector\x12e\n" +
+	"\x10ReportSuiteBegin\x12,.testsystem.v1.events.SuiteBeginEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12a\n" +
+	"\x0eReportSuiteEnd\x12*.testsystem.v1.events.SuiteEndEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12c\n" +
+	"\x0fReportTestBegin\x12+.testsystem.v1.events.TestBeginEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12_\n" +
+	"\rReportTestEnd\x12).testsystem.v1.events.TestEndEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12c\n" +
+	"\x0fReportStepBegin\x12+.testsystem.v1.events.StepBeginEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12_\n" +
+	"\rReportStepEnd\x12).testsystem.v1.events.StepEndEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12g\n" +
+	"\x11ReportTestFailure\x12-.testsystem.v1.events.TestFailureEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12c\n" +
+	"\x0fReportTestError\x12+.testsystem.v1.events.TestErrorEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12a\n" +
+	"\x0eReportStdError\x12*.testsystem.v1.events.StdErrorEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12c\n" +
+	"\x0fReportStdOutput\x12+.testsystem.v1.events.StdOutputEventRequest\x1a#.testsystem.v1.observer.AckResponse\x12]\n" +
+	"\tHeartbeat\x12+.testsystem.v1.events.HeartbeatEventRequest\x1a#.testsystem.v1.observer.AckResponseBd\n" +
 	"'com.stanterprise.testsystem.v1.observerP\x01Z7github.com/stanterprise/proto-go/testsystem/v1/observerb\x06proto3"
 
 var (
@@ -113,23 +121,47 @@ func file_testsystem_v1_observer_observer_proto_rawDescGZIP() []byte {
 
 var file_testsystem_v1_observer_observer_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_testsystem_v1_observer_observer_proto_goTypes = []any{
-	(*AckResponse)(nil),                   // 0: testsystem.v1.observer.AckResponse
-	(*events.TestStartEventRequest)(nil),  // 1: testsystem.v1.events.TestStartEventRequest
-	(*events.TestFinishEventRequest)(nil), // 2: testsystem.v1.events.TestFinishEventRequest
-	(*events.TestStepEventRequest)(nil),   // 3: testsystem.v1.events.TestStepEventRequest
+	(*AckResponse)(nil),                    // 0: testsystem.v1.observer.AckResponse
+	(*events.SuiteBeginEventRequest)(nil),  // 1: testsystem.v1.events.SuiteBeginEventRequest
+	(*events.SuiteEndEventRequest)(nil),    // 2: testsystem.v1.events.SuiteEndEventRequest
+	(*events.TestBeginEventRequest)(nil),   // 3: testsystem.v1.events.TestBeginEventRequest
+	(*events.TestEndEventRequest)(nil),     // 4: testsystem.v1.events.TestEndEventRequest
+	(*events.StepBeginEventRequest)(nil),   // 5: testsystem.v1.events.StepBeginEventRequest
+	(*events.StepEndEventRequest)(nil),     // 6: testsystem.v1.events.StepEndEventRequest
+	(*events.TestFailureEventRequest)(nil), // 7: testsystem.v1.events.TestFailureEventRequest
+	(*events.TestErrorEventRequest)(nil),   // 8: testsystem.v1.events.TestErrorEventRequest
+	(*events.StdErrorEventRequest)(nil),    // 9: testsystem.v1.events.StdErrorEventRequest
+	(*events.StdOutputEventRequest)(nil),   // 10: testsystem.v1.events.StdOutputEventRequest
+	(*events.HeartbeatEventRequest)(nil),   // 11: testsystem.v1.events.HeartbeatEventRequest
 }
 var file_testsystem_v1_observer_observer_proto_depIdxs = []int32{
-	1, // 0: testsystem.v1.observer.TestEventCollector.ReportTestStart:input_type -> testsystem.v1.events.TestStartEventRequest
-	2, // 1: testsystem.v1.observer.TestEventCollector.ReportTestFinish:input_type -> testsystem.v1.events.TestFinishEventRequest
-	3, // 2: testsystem.v1.observer.TestEventCollector.ReportTestStep:input_type -> testsystem.v1.events.TestStepEventRequest
-	0, // 3: testsystem.v1.observer.TestEventCollector.ReportTestStart:output_type -> testsystem.v1.observer.AckResponse
-	0, // 4: testsystem.v1.observer.TestEventCollector.ReportTestFinish:output_type -> testsystem.v1.observer.AckResponse
-	0, // 5: testsystem.v1.observer.TestEventCollector.ReportTestStep:output_type -> testsystem.v1.observer.AckResponse
-	3, // [3:6] is the sub-list for method output_type
-	0, // [0:3] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1,  // 0: testsystem.v1.observer.TestEventCollector.ReportSuiteBegin:input_type -> testsystem.v1.events.SuiteBeginEventRequest
+	2,  // 1: testsystem.v1.observer.TestEventCollector.ReportSuiteEnd:input_type -> testsystem.v1.events.SuiteEndEventRequest
+	3,  // 2: testsystem.v1.observer.TestEventCollector.ReportTestBegin:input_type -> testsystem.v1.events.TestBeginEventRequest
+	4,  // 3: testsystem.v1.observer.TestEventCollector.ReportTestEnd:input_type -> testsystem.v1.events.TestEndEventRequest
+	5,  // 4: testsystem.v1.observer.TestEventCollector.ReportStepBegin:input_type -> testsystem.v1.events.StepBeginEventRequest
+	6,  // 5: testsystem.v1.observer.TestEventCollector.ReportStepEnd:input_type -> testsystem.v1.events.StepEndEventRequest
+	7,  // 6: testsystem.v1.observer.TestEventCollector.ReportTestFailure:input_type -> testsystem.v1.events.TestFailureEventRequest
+	8,  // 7: testsystem.v1.observer.TestEventCollector.ReportTestError:input_type -> testsystem.v1.events.TestErrorEventRequest
+	9,  // 8: testsystem.v1.observer.TestEventCollector.ReportStdError:input_type -> testsystem.v1.events.StdErrorEventRequest
+	10, // 9: testsystem.v1.observer.TestEventCollector.ReportStdOutput:input_type -> testsystem.v1.events.StdOutputEventRequest
+	11, // 10: testsystem.v1.observer.TestEventCollector.Heartbeat:input_type -> testsystem.v1.events.HeartbeatEventRequest
+	0,  // 11: testsystem.v1.observer.TestEventCollector.ReportSuiteBegin:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 12: testsystem.v1.observer.TestEventCollector.ReportSuiteEnd:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 13: testsystem.v1.observer.TestEventCollector.ReportTestBegin:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 14: testsystem.v1.observer.TestEventCollector.ReportTestEnd:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 15: testsystem.v1.observer.TestEventCollector.ReportStepBegin:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 16: testsystem.v1.observer.TestEventCollector.ReportStepEnd:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 17: testsystem.v1.observer.TestEventCollector.ReportTestFailure:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 18: testsystem.v1.observer.TestEventCollector.ReportTestError:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 19: testsystem.v1.observer.TestEventCollector.ReportStdError:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 20: testsystem.v1.observer.TestEventCollector.ReportStdOutput:output_type -> testsystem.v1.observer.AckResponse
+	0,  // 21: testsystem.v1.observer.TestEventCollector.Heartbeat:output_type -> testsystem.v1.observer.AckResponse
+	11, // [11:22] is the sub-list for method output_type
+	0,  // [0:11] is the sub-list for method input_type
+	0,  // [0:0] is the sub-list for extension type_name
+	0,  // [0:0] is the sub-list for extension extendee
+	0,  // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_testsystem_v1_observer_observer_proto_init() }

--- a/testsystem/v1/observer/observer_grpc.pb.go
+++ b/testsystem/v1/observer/observer_grpc.pb.go
@@ -20,18 +20,34 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TestEventCollector_ReportTestStart_FullMethodName  = "/testsystem.v1.observer.TestEventCollector/ReportTestStart"
-	TestEventCollector_ReportTestFinish_FullMethodName = "/testsystem.v1.observer.TestEventCollector/ReportTestFinish"
-	TestEventCollector_ReportTestStep_FullMethodName   = "/testsystem.v1.observer.TestEventCollector/ReportTestStep"
+	TestEventCollector_ReportSuiteBegin_FullMethodName  = "/testsystem.v1.observer.TestEventCollector/ReportSuiteBegin"
+	TestEventCollector_ReportSuiteEnd_FullMethodName    = "/testsystem.v1.observer.TestEventCollector/ReportSuiteEnd"
+	TestEventCollector_ReportTestBegin_FullMethodName   = "/testsystem.v1.observer.TestEventCollector/ReportTestBegin"
+	TestEventCollector_ReportTestEnd_FullMethodName     = "/testsystem.v1.observer.TestEventCollector/ReportTestEnd"
+	TestEventCollector_ReportStepBegin_FullMethodName   = "/testsystem.v1.observer.TestEventCollector/ReportStepBegin"
+	TestEventCollector_ReportStepEnd_FullMethodName     = "/testsystem.v1.observer.TestEventCollector/ReportStepEnd"
+	TestEventCollector_ReportTestFailure_FullMethodName = "/testsystem.v1.observer.TestEventCollector/ReportTestFailure"
+	TestEventCollector_ReportTestError_FullMethodName   = "/testsystem.v1.observer.TestEventCollector/ReportTestError"
+	TestEventCollector_ReportStdError_FullMethodName    = "/testsystem.v1.observer.TestEventCollector/ReportStdError"
+	TestEventCollector_ReportStdOutput_FullMethodName   = "/testsystem.v1.observer.TestEventCollector/ReportStdOutput"
+	TestEventCollector_Heartbeat_FullMethodName         = "/testsystem.v1.observer.TestEventCollector/Heartbeat"
 )
 
 // TestEventCollectorClient is the client API for TestEventCollector service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type TestEventCollectorClient interface {
-	ReportTestStart(ctx context.Context, in *events.TestStartEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
-	ReportTestFinish(ctx context.Context, in *events.TestFinishEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
-	ReportTestStep(ctx context.Context, in *events.TestStepEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportSuiteBegin(ctx context.Context, in *events.SuiteBeginEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportSuiteEnd(ctx context.Context, in *events.SuiteEndEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportTestBegin(ctx context.Context, in *events.TestBeginEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportTestEnd(ctx context.Context, in *events.TestEndEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportStepBegin(ctx context.Context, in *events.StepBeginEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportStepEnd(ctx context.Context, in *events.StepEndEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportTestFailure(ctx context.Context, in *events.TestFailureEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportTestError(ctx context.Context, in *events.TestErrorEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportStdError(ctx context.Context, in *events.StdErrorEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	ReportStdOutput(ctx context.Context, in *events.StdOutputEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
+	Heartbeat(ctx context.Context, in *events.HeartbeatEventRequest, opts ...grpc.CallOption) (*AckResponse, error)
 }
 
 type testEventCollectorClient struct {
@@ -42,30 +58,110 @@ func NewTestEventCollectorClient(cc grpc.ClientConnInterface) TestEventCollector
 	return &testEventCollectorClient{cc}
 }
 
-func (c *testEventCollectorClient) ReportTestStart(ctx context.Context, in *events.TestStartEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+func (c *testEventCollectorClient) ReportSuiteBegin(ctx context.Context, in *events.SuiteBeginEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AckResponse)
-	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestStart_FullMethodName, in, out, cOpts...)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportSuiteBegin_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *testEventCollectorClient) ReportTestFinish(ctx context.Context, in *events.TestFinishEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+func (c *testEventCollectorClient) ReportSuiteEnd(ctx context.Context, in *events.SuiteEndEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AckResponse)
-	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestFinish_FullMethodName, in, out, cOpts...)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportSuiteEnd_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *testEventCollectorClient) ReportTestStep(ctx context.Context, in *events.TestStepEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+func (c *testEventCollectorClient) ReportTestBegin(ctx context.Context, in *events.TestBeginEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AckResponse)
-	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestStep_FullMethodName, in, out, cOpts...)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestBegin_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportTestEnd(ctx context.Context, in *events.TestEndEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestEnd_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportStepBegin(ctx context.Context, in *events.StepBeginEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportStepBegin_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportStepEnd(ctx context.Context, in *events.StepEndEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportStepEnd_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportTestFailure(ctx context.Context, in *events.TestFailureEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestFailure_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportTestError(ctx context.Context, in *events.TestErrorEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportTestError_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportStdError(ctx context.Context, in *events.StdErrorEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportStdError_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) ReportStdOutput(ctx context.Context, in *events.StdOutputEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_ReportStdOutput_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *testEventCollectorClient) Heartbeat(ctx context.Context, in *events.HeartbeatEventRequest, opts ...grpc.CallOption) (*AckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AckResponse)
+	err := c.cc.Invoke(ctx, TestEventCollector_Heartbeat_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +172,17 @@ func (c *testEventCollectorClient) ReportTestStep(ctx context.Context, in *event
 // All implementations must embed UnimplementedTestEventCollectorServer
 // for forward compatibility.
 type TestEventCollectorServer interface {
-	ReportTestStart(context.Context, *events.TestStartEventRequest) (*AckResponse, error)
-	ReportTestFinish(context.Context, *events.TestFinishEventRequest) (*AckResponse, error)
-	ReportTestStep(context.Context, *events.TestStepEventRequest) (*AckResponse, error)
+	ReportSuiteBegin(context.Context, *events.SuiteBeginEventRequest) (*AckResponse, error)
+	ReportSuiteEnd(context.Context, *events.SuiteEndEventRequest) (*AckResponse, error)
+	ReportTestBegin(context.Context, *events.TestBeginEventRequest) (*AckResponse, error)
+	ReportTestEnd(context.Context, *events.TestEndEventRequest) (*AckResponse, error)
+	ReportStepBegin(context.Context, *events.StepBeginEventRequest) (*AckResponse, error)
+	ReportStepEnd(context.Context, *events.StepEndEventRequest) (*AckResponse, error)
+	ReportTestFailure(context.Context, *events.TestFailureEventRequest) (*AckResponse, error)
+	ReportTestError(context.Context, *events.TestErrorEventRequest) (*AckResponse, error)
+	ReportStdError(context.Context, *events.StdErrorEventRequest) (*AckResponse, error)
+	ReportStdOutput(context.Context, *events.StdOutputEventRequest) (*AckResponse, error)
+	Heartbeat(context.Context, *events.HeartbeatEventRequest) (*AckResponse, error)
 	mustEmbedUnimplementedTestEventCollectorServer()
 }
 
@@ -89,14 +193,38 @@ type TestEventCollectorServer interface {
 // pointer dereference when methods are called.
 type UnimplementedTestEventCollectorServer struct{}
 
-func (UnimplementedTestEventCollectorServer) ReportTestStart(context.Context, *events.TestStartEventRequest) (*AckResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ReportTestStart not implemented")
+func (UnimplementedTestEventCollectorServer) ReportSuiteBegin(context.Context, *events.SuiteBeginEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportSuiteBegin not implemented")
 }
-func (UnimplementedTestEventCollectorServer) ReportTestFinish(context.Context, *events.TestFinishEventRequest) (*AckResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ReportTestFinish not implemented")
+func (UnimplementedTestEventCollectorServer) ReportSuiteEnd(context.Context, *events.SuiteEndEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportSuiteEnd not implemented")
 }
-func (UnimplementedTestEventCollectorServer) ReportTestStep(context.Context, *events.TestStepEventRequest) (*AckResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ReportTestStep not implemented")
+func (UnimplementedTestEventCollectorServer) ReportTestBegin(context.Context, *events.TestBeginEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportTestBegin not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportTestEnd(context.Context, *events.TestEndEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportTestEnd not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportStepBegin(context.Context, *events.StepBeginEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportStepBegin not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportStepEnd(context.Context, *events.StepEndEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportStepEnd not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportTestFailure(context.Context, *events.TestFailureEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportTestFailure not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportTestError(context.Context, *events.TestErrorEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportTestError not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportStdError(context.Context, *events.StdErrorEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportStdError not implemented")
+}
+func (UnimplementedTestEventCollectorServer) ReportStdOutput(context.Context, *events.StdOutputEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReportStdOutput not implemented")
+}
+func (UnimplementedTestEventCollectorServer) Heartbeat(context.Context, *events.HeartbeatEventRequest) (*AckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Heartbeat not implemented")
 }
 func (UnimplementedTestEventCollectorServer) mustEmbedUnimplementedTestEventCollectorServer() {}
 func (UnimplementedTestEventCollectorServer) testEmbeddedByValue()                            {}
@@ -119,56 +247,200 @@ func RegisterTestEventCollectorServer(s grpc.ServiceRegistrar, srv TestEventColl
 	s.RegisterService(&TestEventCollector_ServiceDesc, srv)
 }
 
-func _TestEventCollector_ReportTestStart_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(events.TestStartEventRequest)
+func _TestEventCollector_ReportSuiteBegin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.SuiteBeginEventRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(TestEventCollectorServer).ReportTestStart(ctx, in)
+		return srv.(TestEventCollectorServer).ReportSuiteBegin(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: TestEventCollector_ReportTestStart_FullMethodName,
+		FullMethod: TestEventCollector_ReportSuiteBegin_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TestEventCollectorServer).ReportTestStart(ctx, req.(*events.TestStartEventRequest))
+		return srv.(TestEventCollectorServer).ReportSuiteBegin(ctx, req.(*events.SuiteBeginEventRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TestEventCollector_ReportTestFinish_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(events.TestFinishEventRequest)
+func _TestEventCollector_ReportSuiteEnd_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.SuiteEndEventRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(TestEventCollectorServer).ReportTestFinish(ctx, in)
+		return srv.(TestEventCollectorServer).ReportSuiteEnd(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: TestEventCollector_ReportTestFinish_FullMethodName,
+		FullMethod: TestEventCollector_ReportSuiteEnd_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TestEventCollectorServer).ReportTestFinish(ctx, req.(*events.TestFinishEventRequest))
+		return srv.(TestEventCollectorServer).ReportSuiteEnd(ctx, req.(*events.SuiteEndEventRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TestEventCollector_ReportTestStep_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(events.TestStepEventRequest)
+func _TestEventCollector_ReportTestBegin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.TestBeginEventRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(TestEventCollectorServer).ReportTestStep(ctx, in)
+		return srv.(TestEventCollectorServer).ReportTestBegin(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: TestEventCollector_ReportTestStep_FullMethodName,
+		FullMethod: TestEventCollector_ReportTestBegin_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TestEventCollectorServer).ReportTestStep(ctx, req.(*events.TestStepEventRequest))
+		return srv.(TestEventCollectorServer).ReportTestBegin(ctx, req.(*events.TestBeginEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportTestEnd_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.TestEndEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportTestEnd(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportTestEnd_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportTestEnd(ctx, req.(*events.TestEndEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportStepBegin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.StepBeginEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportStepBegin(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportStepBegin_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportStepBegin(ctx, req.(*events.StepBeginEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportStepEnd_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.StepEndEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportStepEnd(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportStepEnd_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportStepEnd(ctx, req.(*events.StepEndEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportTestFailure_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.TestFailureEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportTestFailure(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportTestFailure_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportTestFailure(ctx, req.(*events.TestFailureEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportTestError_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.TestErrorEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportTestError(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportTestError_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportTestError(ctx, req.(*events.TestErrorEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportStdError_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.StdErrorEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportStdError(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportStdError_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportStdError(ctx, req.(*events.StdErrorEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_ReportStdOutput_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.StdOutputEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).ReportStdOutput(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_ReportStdOutput_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).ReportStdOutput(ctx, req.(*events.StdOutputEventRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TestEventCollector_Heartbeat_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(events.HeartbeatEventRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TestEventCollectorServer).Heartbeat(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TestEventCollector_Heartbeat_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TestEventCollectorServer).Heartbeat(ctx, req.(*events.HeartbeatEventRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -181,16 +453,48 @@ var TestEventCollector_ServiceDesc = grpc.ServiceDesc{
 	HandlerType: (*TestEventCollectorServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "ReportTestStart",
-			Handler:    _TestEventCollector_ReportTestStart_Handler,
+			MethodName: "ReportSuiteBegin",
+			Handler:    _TestEventCollector_ReportSuiteBegin_Handler,
 		},
 		{
-			MethodName: "ReportTestFinish",
-			Handler:    _TestEventCollector_ReportTestFinish_Handler,
+			MethodName: "ReportSuiteEnd",
+			Handler:    _TestEventCollector_ReportSuiteEnd_Handler,
 		},
 		{
-			MethodName: "ReportTestStep",
-			Handler:    _TestEventCollector_ReportTestStep_Handler,
+			MethodName: "ReportTestBegin",
+			Handler:    _TestEventCollector_ReportTestBegin_Handler,
+		},
+		{
+			MethodName: "ReportTestEnd",
+			Handler:    _TestEventCollector_ReportTestEnd_Handler,
+		},
+		{
+			MethodName: "ReportStepBegin",
+			Handler:    _TestEventCollector_ReportStepBegin_Handler,
+		},
+		{
+			MethodName: "ReportStepEnd",
+			Handler:    _TestEventCollector_ReportStepEnd_Handler,
+		},
+		{
+			MethodName: "ReportTestFailure",
+			Handler:    _TestEventCollector_ReportTestFailure_Handler,
+		},
+		{
+			MethodName: "ReportTestError",
+			Handler:    _TestEventCollector_ReportTestError_Handler,
+		},
+		{
+			MethodName: "ReportStdError",
+			Handler:    _TestEventCollector_ReportStdError_Handler,
+		},
+		{
+			MethodName: "ReportStdOutput",
+			Handler:    _TestEventCollector_ReportStdOutput_Handler,
+		},
+		{
+			MethodName: "Heartbeat",
+			Handler:    _TestEventCollector_Heartbeat_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
This pull request updates the `TestEventCollector` gRPC API in the test system to support a much more granular and comprehensive set of test lifecycle events. It replaces the previous limited event reporting methods with a suite of new methods that cover suite, test, step, failure, error, output, and heartbeat events. Additionally, it updates the protobuf submodule to the latest version to support these changes.

**API and Protocol Updates:**

* Expanded the `TestEventCollector` gRPC service to include detailed event reporting methods: `ReportSuiteBegin`, `ReportSuiteEnd`, `ReportTestBegin`, `ReportTestEnd`, `ReportStepBegin`, `ReportStepEnd`, `ReportTestFailure`, `ReportTestError`, `ReportStdError`, `ReportStdOutput`, and `Heartbeat`, replacing the previous `ReportTestStart`, `ReportTestFinish`, and `ReportTestStep` methods. This allows for more granular tracking and reporting of the test execution lifecycle. [[1]](diffhunk://#diff-6102c16ada4e6e0283188363e3122f68401073d32bb568a65ab86b83345fa5d1L95-R107) [[2]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L23-R50) [[3]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L45-R164) [[4]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L79-R185) [[5]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L92-R227)

* Updated the generated Go code (`observer.pb.go` and `observer_grpc.pb.go`) to reflect the new service methods and message types, ensuring server and client implementations are compatible with the expanded API. [[1]](diffhunk://#diff-6102c16ada4e6e0283188363e3122f68401073d32bb568a65ab86b83345fa5d1L117-R161) [[2]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L45-R164) [[3]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L79-R185) [[4]](diffhunk://#diff-cb262cbb0a50f15ff5d84c5caf877483b780a7da0a93c32a4de350eb82fb1b00L92-R227)

**Dependency Management:**

* Updated the `protobuf` submodule to version `v0.0.5` to incorporate protocol changes required for the new event types and service methods. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L4-R4) [[2]](diffhunk://#diff-3a38a479ca737fb6b69ac804b5d8f95298ddeaf9ff71f0a3f1ede5fe6f8a29e5L1-R1)

These changes provide a more robust and extensible foundation for observing and collecting detailed test execution events, which will improve diagnostics and reporting in the test system.- Updated observer.proto to include new event reporting methods: ReportSuiteBegin, ReportSuiteEnd, ReportTestBegin, ReportTestEnd, ReportStepBegin, ReportStepEnd, ReportTestFailure, ReportTestError, ReportStdError, ReportStdOutput, and Heartbeat.
- Adjusted the corresponding gRPC client and server interfaces in observer_grpc.pb.go to reflect the new method signatures.
- Removed deprecated methods related to TestStart, TestFinish, and TestStep.
- Ensured all new methods return AckResponse and handle errors appropriately.