### PR TITLE
Update protobuf submodule to v0.1.2 and add ExecutionId field

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "protobuf"]
 	path = protobuf
 	url = https://github.com/stanterprise/protobuf.git
-	tag = v0.1.1
+	tag = v0.1.2

--- a/testsystem/v1/entities/test_case.pb.go
+++ b/testsystem/v1/entities/test_case.pb.go
@@ -45,6 +45,7 @@ type TestCaseRun struct {
 	RetryCount    int32                  `protobuf:"varint,17,opt,name=retry_count,json=retryCount,proto3" json:"retry_count,omitempty"`                                                    // Total number of retry attempts allowed for this test
 	RetryIndex    int32                  `protobuf:"varint,18,opt,name=retry_index,json=retryIndex,proto3" json:"retry_index,omitempty"`                                                    // Current retry attempt index (0 for first attempt)
 	Timeout       int32                  `protobuf:"varint,19,opt,name=timeout,proto3" json:"timeout,omitempty"`                                                                            // Timeout in milliseconds for this test
+	ExecutionId   string                 `protobuf:"bytes,20,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`                                                  // Identifier for the specific execution instance of this test case (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -212,6 +213,13 @@ func (x *TestCaseRun) GetTimeout() int32 {
 	return 0
 }
 
+func (x *TestCaseRun) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 type StepRun struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                                                       // Unique identifier for the step result
@@ -232,6 +240,7 @@ type StepRun struct {
 	Category      string                 `protobuf:"bytes,16,opt,name=category,proto3" json:"category,omitempty"`                                                                          // Category of step (e.g., "hook", "fixture", "test.step")
 	RetryIndex    int32                  `protobuf:"varint,17,opt,name=retry_index,json=retryIndex,proto3" json:"retry_index,omitempty"`                                                   // Current retry attempt index of the parent test case
 	Attachments   []*common.Attachment   `protobuf:"bytes,18,rep,name=attachments,proto3" json:"attachments,omitempty"`                                                                    // Attachments related to the step result
+	ExecutionId   string                 `protobuf:"bytes,19,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`                                                 // Identifier for the specific execution instance of the parent test case run this step belongs to (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -392,11 +401,18 @@ func (x *StepRun) GetAttachments() []*common.Attachment {
 	return nil
 }
 
+func (x *StepRun) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 var File_testsystem_v1_entities_test_case_proto protoreflect.FileDescriptor
 
 const file_testsystem_v1_entities_test_case_proto_rawDesc = "" +
 	"\n" +
-	"&testsystem/v1/entities/test_case.proto\x12\x16testsystem.v1.entities\x1a!testsystem/v1/common/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\xab\x06\n" +
+	"&testsystem/v1/entities/test_case.proto\x12\x16testsystem.v1.entities\x1a!testsystem/v1/common/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\xce\x06\n" +
 	"\vTestCaseRun\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -421,10 +437,11 @@ const file_testsystem_v1_entities_test_case_proto_rawDesc = "" +
 	"retryCount\x12\x1f\n" +
 	"\vretry_index\x18\x12 \x01(\x05R\n" +
 	"retryIndex\x12\x18\n" +
-	"\atimeout\x18\x13 \x01(\x05R\atimeout\x1a;\n" +
+	"\atimeout\x18\x13 \x01(\x05R\atimeout\x12!\n" +
+	"\fexecution_id\x18\x14 \x01(\tR\vexecutionId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe6\x05\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x89\x06\n" +
 	"\aStepRun\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12 \n" +
@@ -447,7 +464,8 @@ const file_testsystem_v1_entities_test_case_proto_rawDesc = "" +
 	"\bcategory\x18\x10 \x01(\tR\bcategory\x12\x1f\n" +
 	"\vretry_index\x18\x11 \x01(\x05R\n" +
 	"retryIndex\x12B\n" +
-	"\vattachments\x18\x12 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\x1a;\n" +
+	"\vattachments\x18\x12 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\x12!\n" +
+	"\fexecution_id\x18\x13 \x01(\tR\vexecutionId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01Bd\n" +

--- a/testsystem/v1/entities/test_suite.pb.go
+++ b/testsystem/v1/entities/test_suite.pb.go
@@ -98,6 +98,7 @@ type TestSuiteRun struct {
 	Owner         string                 `protobuf:"bytes,18,opt,name=owner,proto3" json:"owner,omitempty"`                                                                                // Team or individual responsible for the test suite
 	TestCases     []*TestCaseRun         `protobuf:"bytes,19,rep,name=test_cases,json=testCases,proto3" json:"test_cases,omitempty"`                                                       // Nested test case objects (optional, for sending full structure)
 	SubSuites     []*TestSuiteRun        `protobuf:"bytes,20,rep,name=sub_suites,json=subSuites,proto3" json:"sub_suites,omitempty"`                                                       // Nested test suite objects (optional, for sending full structure)
+	ExecutionId   string                 `protobuf:"bytes,21,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`                                                 // Identifier for the specific execution instance of this test suite run (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -272,11 +273,18 @@ func (x *TestSuiteRun) GetSubSuites() []*TestSuiteRun {
 	return nil
 }
 
+func (x *TestSuiteRun) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 var File_testsystem_v1_entities_test_suite_proto protoreflect.FileDescriptor
 
 const file_testsystem_v1_entities_test_suite_proto_rawDesc = "" +
 	"\n" +
-	"'testsystem/v1/entities/test_suite.proto\x12\x16testsystem.v1.entities\x1a!testsystem/v1/common/common.proto\x1a&testsystem/v1/entities/test_case.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\x92\a\n" +
+	"'testsystem/v1/entities/test_suite.proto\x12\x16testsystem.v1.entities\x1a!testsystem/v1/common/common.proto\x1a&testsystem/v1/entities/test_case.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\xb5\a\n" +
 	"\fTestSuiteRun\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -301,7 +309,8 @@ const file_testsystem_v1_entities_test_suite_proto_rawDesc = "" +
 	"\n" +
 	"test_cases\x18\x13 \x03(\v2#.testsystem.v1.entities.TestCaseRunR\ttestCases\x12C\n" +
 	"\n" +
-	"sub_suites\x18\x14 \x03(\v2$.testsystem.v1.entities.TestSuiteRunR\tsubSuites\x1a;\n" +
+	"sub_suites\x18\x14 \x03(\v2$.testsystem.v1.entities.TestSuiteRunR\tsubSuites\x12!\n" +
+	"\fexecution_id\x18\x15 \x01(\tR\vexecutionId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*:\n" +

--- a/testsystem/v1/events/events.pb.go
+++ b/testsystem/v1/events/events.pb.go
@@ -210,6 +210,7 @@ type TestFailureEventRequest struct {
 	Attachments    []*common.Attachment   `protobuf:"bytes,5,rep,name=attachments,proto3" json:"attachments,omitempty"`
 	RunId          string                 `protobuf:"bytes,6,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	RetryIndex     int32                  `protobuf:"varint,7,opt,name=retry_index,json=retryIndex,proto3" json:"retry_index,omitempty"`
+	ExecutionId    string                 `protobuf:"bytes,8,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"` // Identifier for the specific execution instance of this test case (useful for parallel runs)
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -293,6 +294,13 @@ func (x *TestFailureEventRequest) GetRetryIndex() int32 {
 	return 0
 }
 
+func (x *TestFailureEventRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 type TestErrorEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
@@ -302,6 +310,7 @@ type TestErrorEventRequest struct {
 	Attachments   []*common.Attachment   `protobuf:"bytes,5,rep,name=attachments,proto3" json:"attachments,omitempty"`
 	RunId         string                 `protobuf:"bytes,6,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	RetryIndex    int32                  `protobuf:"varint,7,opt,name=retry_index,json=retryIndex,proto3" json:"retry_index,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,8,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"` // Identifier for the specific execution instance of this test case (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -385,6 +394,13 @@ func (x *TestErrorEventRequest) GetRetryIndex() int32 {
 	return 0
 }
 
+func (x *TestErrorEventRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 type StdErrorEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
@@ -393,6 +409,7 @@ type StdErrorEventRequest struct {
 	TestCaseRunId string                 `protobuf:"bytes,4,opt,name=test_case_run_id,json=testCaseRunId,proto3" json:"test_case_run_id,omitempty"` // Reference to the specific test case run
 	RunId         string                 `protobuf:"bytes,5,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	RetryIndex    int32                  `protobuf:"varint,6,opt,name=retry_index,json=retryIndex,proto3" json:"retry_index,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,7,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"` // Identifier for the specific execution instance of this test case (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -469,6 +486,13 @@ func (x *StdErrorEventRequest) GetRetryIndex() int32 {
 	return 0
 }
 
+func (x *StdErrorEventRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 type StdOutputEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TestId        string                 `protobuf:"bytes,1,opt,name=test_id,json=testId,proto3" json:"test_id,omitempty"`
@@ -477,6 +501,7 @@ type StdOutputEventRequest struct {
 	TestCaseRunId string                 `protobuf:"bytes,4,opt,name=test_case_run_id,json=testCaseRunId,proto3" json:"test_case_run_id,omitempty"` // Reference to the specific test case run
 	RunId         string                 `protobuf:"bytes,5,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	RetryIndex    int32                  `protobuf:"varint,6,opt,name=retry_index,json=retryIndex,proto3" json:"retry_index,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,7,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"` // Identifier for the specific execution instance of this test case (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -551,6 +576,13 @@ func (x *StdOutputEventRequest) GetRetryIndex() int32 {
 		return x.RetryIndex
 	}
 	return 0
+}
+
+func (x *StdOutputEventRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
 }
 
 type SuiteBeginEventRequest struct {
@@ -700,6 +732,7 @@ type ReportRunStartEventRequest struct {
 	TotalTests    int32                    `protobuf:"varint,3,opt,name=total_tests,json=totalTests,proto3" json:"total_tests,omitempty"`
 	Name          string                   `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
 	Metadata      map[string]string        `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExecutionId   string                   `protobuf:"bytes,6,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"` // Identifier for the specific execution instance of this run (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -769,6 +802,13 @@ func (x *ReportRunStartEventRequest) GetMetadata() map[string]string {
 	return nil
 }
 
+func (x *ReportRunStartEventRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 type TestRunEndEventRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
@@ -776,6 +816,7 @@ type TestRunEndEventRequest struct {
 	StartTime     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
 	Duration      *durationpb.Duration   `protobuf:"bytes,4,opt,name=duration,proto3" json:"duration,omitempty"`
 	Metadata      map[string]string      `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExecutionId   string                 `protobuf:"bytes,6,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"` // Identifier for the specific execution instance of this test run (useful for parallel runs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -845,6 +886,13 @@ func (x *TestRunEndEventRequest) GetMetadata() map[string]string {
 	return nil
 }
 
+func (x *TestRunEndEventRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
 var File_testsystem_v1_events_events_proto protoreflect.FileDescriptor
 
 const file_testsystem_v1_events_events_proto_rawDesc = "" +
@@ -857,7 +905,7 @@ const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\x15StepBeginEventRequest\x123\n" +
 	"\x04step\x18\x01 \x01(\v2\x1f.testsystem.v1.entities.StepRunR\x04step\"J\n" +
 	"\x13StepEndEventRequest\x123\n" +
-	"\x04step\x18\x01 \x01(\v2\x1f.testsystem.v1.entities.StepRunR\x04step\"\xb2\x02\n" +
+	"\x04step\x18\x01 \x01(\v2\x1f.testsystem.v1.entities.StepRunR\x04step\"\xd5\x02\n" +
 	"\x17TestFailureEventRequest\x12\x17\n" +
 	"\atest_id\x18\x01 \x01(\tR\x06testId\x12'\n" +
 	"\x0ffailure_message\x18\x02 \x01(\tR\x0efailureMessage\x12\x1f\n" +
@@ -867,7 +915,8 @@ const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\vattachments\x18\x05 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\x12\x15\n" +
 	"\x06run_id\x18\x06 \x01(\tR\x05runId\x12\x1f\n" +
 	"\vretry_index\x18\a \x01(\x05R\n" +
-	"retryIndex\"\xac\x02\n" +
+	"retryIndex\x12!\n" +
+	"\fexecution_id\x18\b \x01(\tR\vexecutionId\"\xcf\x02\n" +
 	"\x15TestErrorEventRequest\x12\x17\n" +
 	"\atest_id\x18\x01 \x01(\tR\x06testId\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x1f\n" +
@@ -877,7 +926,8 @@ const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\vattachments\x18\x05 \x03(\v2 .testsystem.v1.common.AttachmentR\vattachments\x12\x15\n" +
 	"\x06run_id\x18\x06 \x01(\tR\x05runId\x12\x1f\n" +
 	"\vretry_index\x18\a \x01(\x05R\n" +
-	"retryIndex\"\xe4\x01\n" +
+	"retryIndex\x12!\n" +
+	"\fexecution_id\x18\b \x01(\tR\vexecutionId\"\x87\x02\n" +
 	"\x14StdErrorEventRequest\x12\x17\n" +
 	"\atest_id\x18\x01 \x01(\tR\x06testId\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x128\n" +
@@ -885,7 +935,8 @@ const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\x10test_case_run_id\x18\x04 \x01(\tR\rtestCaseRunId\x12\x15\n" +
 	"\x06run_id\x18\x05 \x01(\tR\x05runId\x12\x1f\n" +
 	"\vretry_index\x18\x06 \x01(\x05R\n" +
-	"retryIndex\"\xe5\x01\n" +
+	"retryIndex\x12!\n" +
+	"\fexecution_id\x18\a \x01(\tR\vexecutionId\"\x88\x02\n" +
 	"\x15StdOutputEventRequest\x12\x17\n" +
 	"\atest_id\x18\x01 \x01(\tR\x06testId\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x128\n" +
@@ -893,14 +944,15 @@ const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\x10test_case_run_id\x18\x04 \x01(\tR\rtestCaseRunId\x12\x15\n" +
 	"\x06run_id\x18\x05 \x01(\tR\x05runId\x12\x1f\n" +
 	"\vretry_index\x18\x06 \x01(\x05R\n" +
-	"retryIndex\"T\n" +
+	"retryIndex\x12!\n" +
+	"\fexecution_id\x18\a \x01(\tR\vexecutionId\"T\n" +
 	"\x16SuiteBeginEventRequest\x12:\n" +
 	"\x05suite\x18\x01 \x01(\v2$.testsystem.v1.entities.TestSuiteRunR\x05suite\"R\n" +
 	"\x14SuiteEndEventRequest\x12:\n" +
 	"\x05suite\x18\x01 \x01(\v2$.testsystem.v1.entities.TestSuiteRunR\x05suite\"n\n" +
 	"\x15HeartbeatEventRequest\x12\x1b\n" +
 	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x128\n" +
-	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xc8\x02\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xeb\x02\n" +
 	"\x1aReportRunStartEventRequest\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12E\n" +
 	"\vtest_suites\x18\x02 \x03(\v2$.testsystem.v1.entities.TestSuiteRunR\n" +
@@ -908,17 +960,19 @@ const file_testsystem_v1_events_events_proto_rawDesc = "" +
 	"\vtotal_tests\x18\x03 \x01(\x05R\n" +
 	"totalTests\x12\x12\n" +
 	"\x04name\x18\x04 \x01(\tR\x04name\x12Z\n" +
-	"\bmetadata\x18\x05 \x03(\v2>.testsystem.v1.events.ReportRunStartEventRequest.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x05 \x03(\v2>.testsystem.v1.events.ReportRunStartEventRequest.MetadataEntryR\bmetadata\x12!\n" +
+	"\fexecution_id\x18\x06 \x01(\tR\vexecutionId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9e\x03\n" +
 	"\x16TestRunEndEventRequest\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12C\n" +
 	"\ffinal_status\x18\x02 \x01(\x0e2 .testsystem.v1.common.TestStatusR\vfinalStatus\x129\n" +
 	"\n" +
 	"start_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x125\n" +
 	"\bduration\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12V\n" +
-	"\bmetadata\x18\x05 \x03(\v2:.testsystem.v1.events.TestRunEndEventRequest.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x05 \x03(\v2:.testsystem.v1.events.TestRunEndEventRequest.MetadataEntryR\bmetadata\x12!\n" +
+	"\fexecution_id\x18\x06 \x01(\tR\vexecutionId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B`\n" +


### PR DESCRIPTION
This pull request introduces support for tracking execution instances across test runs, suites, cases, steps, and related events, which is essential for handling parallel test executions. The main change is the addition of a new `execution_id` field to various protocol buffer messages and their generated Go types. This allows each test execution instance to be uniquely identified, improving traceability and debugging in parallel or distributed test environments.

Key changes include:

**Protobuf Submodule Update**
- Updated the `protobuf` submodule from version `v0.1.1` to `v0.1.2`, pulling in the latest schema changes. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L4-R4) [[2]](diffhunk://#diff-3a38a479ca737fb6b69ac804b5d8f95298ddeaf9ff71f0a3f1ede5fe6f8a29e5L1-R1)

**Schema and Generated Code Enhancements for Execution Tracking**
- Added an `ExecutionId` field to the following types in `testsystem/v1/entities/test_case.pb.go`:
  - `TestCaseRun`: Identifies the specific execution instance of a test case run.
  - `StepRun`: Identifies the execution instance of the parent test case run for each step.
  - Getter methods for these fields were also generated. [[1]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1R48) [[2]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1R216-R222) [[3]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1R243) [[4]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1R404-R415) [[5]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1L424-R444) [[6]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1L450-R468)

- Added an `ExecutionId` field to `TestSuiteRun` in `testsystem/v1/entities/test_suite.pb.go` and generated the corresponding getter. [[1]](diffhunk://#diff-3de3a386398cbfea420218d6f94373a0dfe6eb669321dfd0ea7bea8f73cefcbcR101) [[2]](diffhunk://#diff-3de3a386398cbfea420218d6f94373a0dfe6eb669321dfd0ea7bea8f73cefcbcR276-R287) [[3]](diffhunk://#diff-3de3a386398cbfea420218d6f94373a0dfe6eb669321dfd0ea7bea8f73cefcbcL304-R313)

**Event Message Updates for Execution Tracking**
- Added an `ExecutionId` field to all relevant event request types in `testsystem/v1/events/events.pb.go`, including:
  - `TestFailureEventRequest`
  - `TestErrorEventRequest`
  - `StdErrorEventRequest`
  - `StdOutputEventRequest`
  - `ReportRunStartEventRequest`
  - `TestRunEndEventRequest`
  - Corresponding getter methods were generated for each. [[1]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR213) [[2]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR297-R303) [[3]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR313) [[4]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR397-R403) [[5]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR412) [[6]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR489-R495) [[7]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR504) [[8]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR581-R587) [[9]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR735) [[10]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR805-R819) [[11]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cR889-R895)

**Protobuf Descriptor Updates**
- Updated the raw protobuf descriptor strings to reflect the new `execution_id` fields throughout the generated Go files. [[1]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1L424-R444) [[2]](diffhunk://#diff-3d9a86290ea4e7f67ddcb101bc558e1dce8a97d5633b0da58fd583c69a4c10a1L450-R468) [[3]](diffhunk://#diff-3de3a386398cbfea420218d6f94373a0dfe6eb669321dfd0ea7bea8f73cefcbcL304-R313) [[4]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cL860-R908) [[5]](diffhunk://#diff-9f491094e834d1502064d0cdaa2df598792e4218507543e33102bcd43638f99cL870-R919)

These changes collectively enable more robust tracking and correlation of test execution instances, especially in parallelized test environments.